### PR TITLE
bar使用不复权数据回测

### DIFF
--- a/rqalpha_mod_tushare/data_source.py
+++ b/rqalpha_mod_tushare/data_source.py
@@ -37,7 +37,9 @@ class TushareKDataSource(BaseDataSource):
         else:
             return None
 
-        return ts.get_k_data(code, index=index, start=start_dt.strftime('%Y-%m-%d'), end=end_dt.strftime('%Y-%m-%d'))
+        return ts.get_k_data(code, index=index, autype='bfq',
+                             start=start_dt.strftime('%Y-%m-%d'),
+                             end=end_dt.strftime('%Y-%m-%d'))
 
     def get_bar(self, instrument, dt, frequency):
         if frequency != '1d':


### PR DESCRIPTION
get_k_data接口默认获取的行情数据为前复权数据，这里改为不复权的行情数据。